### PR TITLE
Update inference_speech_editing.ipynb

### DIFF
--- a/inference_speech_editing.ipynb
+++ b/inference_speech_editing.ipynb
@@ -99,7 +99,7 @@
     "# run MFA to get the alignment\n",
     "align_temp = f\"{temp_folder}/mfa_alignments\"\n",
     "os.makedirs(align_temp, exist_ok=True)\n",
-    "# os.system(f\"mfa align -j 1 --output_format csv {temp_folder} english_us_arpa english_us_arpa {align_temp}\")\n",
+    "os.system(f\"mfa align -j 1 --output_format csv {temp_folder} english_us_arpa english_us_arpa {align_temp}\")\n",
     "# if it fail, it could be because the audio is too hard for the alignment model, increasing the beam size usually solves the issue\n",
     "# os.system(f\"mfa align -j 1 --output_format csv {temp_folder} english_us_arpa english_us_arpa {align_temp} --beam 1000 --retry_beam 2000\")\n",
     "audio_fn = f\"{temp_folder}/{filename}.wav\"\n",


### PR DESCRIPTION
enable one alignment. Both the MFA alignments are commented out (accidentally I presume).
Enabling the first one which fixes this script