### PR TITLE
Empty cuda cache between inferences.

### DIFF
--- a/inference_tts_scale.py
+++ b/inference_tts_scale.py
@@ -98,7 +98,9 @@ def inference_one_sample(model, model_args, phn2num, text_tokenizer, audio_token
     gen_sample = audio_tokenizer.decode(
         [(gen_frames, None)]
     )
-
+    #Empty cuda cache between runs
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     # return
     return concat_sample, gen_sample
 


### PR DESCRIPTION
I noticed large amounts of memory allocated between runs and tried to find out why. After you generate some TTS it will now go back down. Tested it with the gradio ui.