### PR TITLE
Add hf

### DIFF
--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -18,6 +18,7 @@ from .modules.transformer import (
 )
 from .codebooks_patterns import DelayedPatternProvider
 
+from argparse import Namespace
 from huggingface_hub import PyTorchModelHubMixin
 
 
@@ -1415,4 +1416,5 @@ class VoiceCraft(nn.Module):
 
 class VoiceCraftHF(VoiceCraft, PyTorchModelHubMixin):
     def __init__(self, config: dict):
-        super().__init__(config)
+        args = Namespace(**config)
+        super().__init__(args)

--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -18,6 +18,9 @@ from .modules.transformer import (
 )
 from .codebooks_patterns import DelayedPatternProvider
 
+from huggingface_hub import PyTorchModelHubMixin
+
+
 def top_k_top_p_filtering(
     logits, top_k=0, top_p=1.0, filter_value=-float("Inf"), min_tokens_to_keep=1
 ):
@@ -82,7 +85,7 @@ def topk_sampling(logits, top_k=10, top_p=1.0, temperature=1.0):
 
 
 
-class VoiceCraft(nn.Module):
+class VoiceCraft(nn.Module, PyTorchModelHubMixin):
     def __init__(self, args):
         super().__init__()
         self.args = copy.copy(args)

--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -85,7 +85,7 @@ def topk_sampling(logits, top_k=10, top_p=1.0, temperature=1.0):
 
 
 
-class VoiceCraft(nn.Module, PyTorchModelHubMixin):
+class VoiceCraft(nn.Module):
     def __init__(self, args):
         super().__init__()
         self.args = copy.copy(args)
@@ -1411,3 +1411,8 @@ class VoiceCraft(nn.Module, PyTorchModelHubMixin):
             flatten_gen = flatten_gen - int(self.args.n_special)
 
         return res, flatten_gen[0].unsqueeze(0)
+    
+
+class VoiceCraftHF(VoiceCraft, PyTorchModelHubMixin):
+    def __init__(self, config: dict):
+        super().__init__(config)


### PR DESCRIPTION
Dear authors,

I noticed your awesome repository trending on paperswithcode. I'm from Hugging Face, and I see all checkpoints are on 🤗 
already, but present in a [single repository](https://huggingface.co/pyp1/VoiceCraft/tree/main), which means download metrics won't work. 😞 

This PR resolves that by showcasing the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class, which is a minimal class that allows to easily add functionalities like `from_pretrained`, `save_pretrained`, and `push_to_hub` to any custom `nn.Module` (without the need to rely on Torch hub or define your own `from_pretrained`). 

Similar to models in the Transformers/Diffusers library, it allows to push and reload models in the format of `safetensors` (for the weights) and a `config.json` (for the model's configuration). It also creates an automated model card, along with tags for better discoverability of your models. Usage is as follows:

```
from models.voicecraft import VoiceCraftHF

model = VoiceCraftHF.from_pretrained(f"nielsr/{voicecraft_name}")
```
The corresponding model is here for now: https://huggingface.co/nielsr/gigaHalfLibri330M_TTSEnhanced_max16s, but I could transfer it (along with the other checkpoints) to your organization.

This ensures:
✅ download metrics will work for you
✅ tags are added to the model card automatically which means people can easier find the models on the hub (better discoverability)
✅ reloading the model is just a single line of code

Here's a [notebook](https://colab.research.google.com/drive/1IyKOu8rnwNaWzjleaB5ZzgUW60WOc_ou?usp=sharing) regarding how I did that :)

Btw, there's no need for a wget in the demo notebooks, you can leverage [hf_hub_download](https://huggingface.co/docs/huggingface_hub/en/guides/download#download-a-single-file) to load a file in a single line of code! This is also illustrated in my notebook above.

Would you be interested in this integration?

Kind regards,

Niels
ML @ HF