### PR TITLE
Tweak VoiceCraft x HF integration

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -92,7 +92,7 @@ def load_models(whisper_backend_name, whisper_model_name, alignment_model_name, 
             transcribe_model = WhisperxModel(whisper_model_name, align_model)
 
     voicecraft_name = f"{voicecraft_model_name}.pth"
-    model = voicecraft.VoiceCraftHF.from_pretrained(f"pyp1/VoiceCraft_{voicecraft_name.replace('.pth', '')}")
+    model = voicecraft.VoiceCraft.from_pretrained(f"pyp1/VoiceCraft_{voicecraft_name.replace('.pth', '')}")
     phn2num = model.args.phn2num
     config = model.args
     model.to(device)

--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -1420,7 +1420,7 @@ class VoiceCraftHF(
         VoiceCraft,
         PyTorchModelHubMixin,
         repo_url="https://github.com/jasonppy/VoiceCraft",
-        tags=["Text-to-Speech"],
+        tags=["text-to-speech"],
         library_name="voicecraft"
     ):
     def __init__(self, config: dict):

--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -1416,7 +1416,13 @@ class VoiceCraft(nn.Module):
         return res, flatten_gen[0].unsqueeze(0)
     
 
-class VoiceCraftHF(VoiceCraft, PyTorchModelHubMixin, repo_url="https://github.com/jasonppy/VoiceCraft", tags=["Text-to-Speech", "VoiceCraft"]):
+class VoiceCraftHF(
+        VoiceCraft,
+        PyTorchModelHubMixin,
+        repo_url="https://github.com/jasonppy/VoiceCraft",
+        tags=["Text-to-Speech"],
+        library_name="voicecraft"
+    ):
     def __init__(self, config: dict):
         args = Namespace(**config)
         super().__init__(args)

--- a/models/voicecraft.py
+++ b/models/voicecraft.py
@@ -3,6 +3,7 @@ import random
 import numpy as np
 import logging
 import argparse, copy
+from typing import Dict, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -86,9 +87,31 @@ def topk_sampling(logits, top_k=10, top_p=1.0, temperature=1.0):
 
 
 
-class VoiceCraft(nn.Module):
-    def __init__(self, args):
+class VoiceCraft(
+        nn.Module,
+        PyTorchModelHubMixin,
+        library_name="voicecraft",
+        repo_url="https://github.com/jasonppy/VoiceCraft",
+        tags=["text-to-speech"],
+    ):
+    def __new__(cls, args: Optional[Namespace] = None, config: Optional[Dict] = None, **kwargs) -> "VoiceCraft":
+        # If initialized from Namespace args => convert to dict config for 'PyTorchModelHubMixin' to serialize it as config.json
+        # Won't affect instance initialization
+        if args is not None:
+            if config is not None:
+                raise ValueError("Cannot provide both `args` and `config`.")
+            config = vars(args)
+        return super().__new__(cls, args=args, config=config, **kwargs)
+
+    def __init__(self, args: Optional[Namespace] = None, config: Optional[Dict] = None):
         super().__init__()
+
+        # If loaded from HF Hub => convert config.json to Namespace args before initializing
+        if args is None:
+            if config is None:
+                raise ValueError("Either `args` or `config` must be provided.")
+            args = Namespace(**config)
+
         self.args = copy.copy(args)
         self.pattern = DelayedPatternProvider(n_q=self.args.n_codebooks)
         if not getattr(self.args, "special_first", False):
@@ -100,7 +123,7 @@ class VoiceCraft(nn.Module):
         if self.args.eos > 0:
             assert self.args.eos != self.args.audio_pad_token and self.args.eos != self.args.empty_token, self.args.eos
             self.eos = nn.Parameter(torch.full((self.args.n_codebooks, 1), self.args.eos, dtype=torch.long), requires_grad=False) # [K 1]
-        if type(self.args.audio_vocab_size) == str:
+        if isinstance(self.args.audio_vocab_size, str):
             self.args.audio_vocab_size = eval(self.args.audio_vocab_size)
 
         self.n_text_tokens = self.args.text_vocab_size + 1
@@ -1414,15 +1437,3 @@ class VoiceCraft(nn.Module):
             flatten_gen = flatten_gen - int(self.args.n_special)
 
         return res, flatten_gen[0].unsqueeze(0)
-    
-
-class VoiceCraftHF(
-        VoiceCraft,
-        PyTorchModelHubMixin,
-        repo_url="https://github.com/jasonppy/VoiceCraft",
-        tags=["text-to-speech"],
-        library_name="voicecraft"
-    ):
-    def __init__(self, config: dict):
-        args = Namespace(**config)
-        super().__init__(args)


### PR DESCRIPTION
This PR tweaks the HF integrations:
- `VoiceCraft` tag is lowercased to `voicecraft` => not a hard requirement but makes it more consistent with other libraries on the Hub.
- `voicecraft` is set as the `library_name` instead of simply a tag. This is better for taxonomy on the Hub.
- `Text-to-Speech` is lowercased to be recognized as a task by the HF Hub
- `VoiceCraftHF` class has been removed to have a single `VoiceCraft`. Requires a small update at init (see https://github.com/jasonppy/VoiceCraft/pull/90/commits/e550f614096a9ba098d2127a4e441ca497ba256f) but it'll make the process much smoother for end users. With this change, it'll be possible for users to retrain a `VoiceCraft` object and push it to the Hub with `VoiceCraft(...).push_to_hub(...)` which was not the case before. 

Regarding the integration, I also opened https://github.com/huggingface/huggingface.js/pull/626 to make it more official on the Hub. In particular, there will now be an official `</> Use in VoiceCraft`  button in all voicecraft models that display the code snippet to load the model. This should help users getting started with the model. It will also add a link to the voicecraft repo for the installation guide.

cc @NielsRogge who opened https://github.com/jasonppy/VoiceCraft/pull/78


**EDIT:** I also opened PR on existing models to reflect these changes.
- https://huggingface.co/pyp1/VoiceCraft_gigaHalfLibri330M_TTSEnhanced_max16s/discussions/1
- https://huggingface.co/pyp1/VoiceCraft_giga830M/discussions/1
- https://huggingface.co/pyp1/VoiceCraft_giga330M/discussions/1
- https://huggingface.co/nielsr/gigaHalfLibri330M_TTSEnhanced_max16s/discussions/1