### PR TITLE
Update huggingface-hub to version that exists

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -308,7 +308,7 @@ dependencies:
       - h11==0.14.0
       - httpcore==1.0.4
       - httpx==0.27.0
-      - huggingface-hub==0.22.4
+      - huggingface-hub==0.22.2
       - hydra-colorlog==1.2.0
       - hydra-core==1.3.2
       - ipython==8.12.3


### PR DESCRIPTION
Latest version as of today is 0.22.2 [huggingface-hub](https://github.com/huggingface/huggingface_hub/releases).

Likely cause of this issue is manual edit in the environments.yml.