### PR TITLE
Upgrade huggingface-hub dependency to 0.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN conda update -y -n base -c conda-forge conda && \
     conda run -n voicecraft pip install phonemizer==3.2.1 && \
     conda run -n voicecraft pip install datasets==2.16.0 && \
     conda run -n voicecraft pip install torchmetrics==0.11.1 && \
-    conda run -n voicecraft pip install huggingface_hub==0.22.2
+    conda run -n voicecraft pip install huggingface_hub==0.23.0
     
 
 # Install the Jupyter kernel

--- a/environment.yml
+++ b/environment.yml
@@ -308,7 +308,7 @@ dependencies:
       - h11==0.14.0
       - httpcore==1.0.4
       - httpx==0.27.0
-      - huggingface-hub==0.22.2
+      - huggingface-hub==0.23.0
       - hydra-colorlog==1.2.0
       - hydra-core==1.3.2
       - ipython==8.12.3


### PR DESCRIPTION
In latest run of notebook I receive the error `ImportError: huggingface-hub>=0.23.0,<1.0 is required for a normal functioning of this module, but found huggingface-hub==0.22.2.` Upgrading the dependency fixes it.